### PR TITLE
Implemented Resume Builder API - Upload & Fetch Resumes

### DIFF
--- a/src/main/java/com/opencode/alumxbackend/resume/controller/ResumeController.java
+++ b/src/main/java/com/opencode/alumxbackend/resume/controller/ResumeController.java
@@ -1,0 +1,46 @@
+package com.opencode.alumxbackend.resume.controller;
+
+import com.opencode.alumxbackend.resume.model.Resume;
+import com.opencode.alumxbackend.resume.service.ResumeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@RestController
+@RequestMapping("/api/resumes")
+@RequiredArgsConstructor
+public class ResumeController {
+
+    private final ResumeService resumeService;
+
+    @PostMapping
+    public ResponseEntity<?> uploadResume(
+            @RequestParam String userId,
+            @RequestParam MultipartFile file
+    ) throws Exception {
+        resumeService.uploadResume(userId, file);
+        return ResponseEntity.ok("Resume uploaded successfully");
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<?> fetchResume(@PathVariable String userId) throws Exception {
+
+        Resume resume = resumeService.getResumeByUserId(userId);
+        Path path = Path.of(resume.getFilePath());
+
+        ByteArrayResource resource = new ByteArrayResource(Files.readAllBytes(path));
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + resume.getFileName() + "\"")
+                .contentType(MediaType.parseMediaType(resume.getFileType()))
+                .body(resource);
+    }
+}

--- a/src/main/java/com/opencode/alumxbackend/resume/dto/ResumeResponseDto.java
+++ b/src/main/java/com/opencode/alumxbackend/resume/dto/ResumeResponseDto.java
@@ -1,0 +1,13 @@
+package com.opencode.alumxbackend.resume.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ResumeResponseDto {
+    private String id;
+    private String userId;
+    private String fileName;
+    private String fileType;
+}

--- a/src/main/java/com/opencode/alumxbackend/resume/exception/InvalidResumeException.java
+++ b/src/main/java/com/opencode/alumxbackend/resume/exception/InvalidResumeException.java
@@ -1,0 +1,7 @@
+package com.opencode.alumxbackend.resume.exception;
+
+public class InvalidResumeException extends RuntimeException{
+    public InvalidResumeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/opencode/alumxbackend/resume/exception/ResumeNotFoundException.java
+++ b/src/main/java/com/opencode/alumxbackend/resume/exception/ResumeNotFoundException.java
@@ -1,0 +1,7 @@
+package com.opencode.alumxbackend.resume.exception;
+
+public class ResumeNotFoundException extends RuntimeException {
+    public ResumeNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/opencode/alumxbackend/resume/model/Resume.java
+++ b/src/main/java/com/opencode/alumxbackend/resume/model/Resume.java
@@ -1,0 +1,34 @@
+package com.opencode.alumxbackend.resume.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Resume {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @Column(nullable = false)
+    private String userId;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String fileType;
+
+    @Column(nullable = false)
+    private String filePath;
+
+    private LocalDateTime uploadedAt;
+}
+

--- a/src/main/java/com/opencode/alumxbackend/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/opencode/alumxbackend/resume/repository/ResumeRepository.java
@@ -1,0 +1,10 @@
+package com.opencode.alumxbackend.resume.repository;
+
+import com.opencode.alumxbackend.resume.model.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ResumeRepository extends JpaRepository<Resume,String> {
+    Optional<Resume> findByUserId(String userId);
+}

--- a/src/main/java/com/opencode/alumxbackend/resume/service/ResumeService.java
+++ b/src/main/java/com/opencode/alumxbackend/resume/service/ResumeService.java
@@ -1,0 +1,57 @@
+package com.opencode.alumxbackend.resume.service;
+
+import com.opencode.alumxbackend.resume.exception.InvalidResumeException;
+import com.opencode.alumxbackend.resume.exception.ResumeNotFoundException;
+import com.opencode.alumxbackend.resume.model.Resume;
+import com.opencode.alumxbackend.resume.repository.ResumeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeService {
+    private final ResumeRepository resumeRepository;
+
+    @Value("${resume.upload.dir}")
+    private String uploadDir;
+
+    public void uploadResume(String userId, MultipartFile file) throws Exception {
+
+        if (file.getSize() > 5 * 1024 * 1024) {
+            throw new InvalidResumeException("File size must be less than 5MB");
+        }
+
+        String contentType = file.getContentType();
+        if (!("application/pdf".equals(contentType)
+                || "application/vnd.openxmlformats-officedocument.wordprocessingml.document".equals(contentType))) {
+            throw new InvalidResumeException("Only PDF and DOCX files are allowed");
+        }
+
+        File directory = new File(uploadDir);
+        if (!directory.exists()) directory.mkdirs();
+
+        String filePath = uploadDir + "/" + userId + "_" + file.getOriginalFilename();
+        Files.write(new File(filePath).toPath(), file.getBytes());
+
+        Resume resume = Resume.builder()
+                .userId(userId)
+                .fileName(file.getOriginalFilename())
+                .fileType(contentType)
+                .filePath(filePath)
+                .uploadedAt(LocalDateTime.now())
+                .build();
+
+        resumeRepository.save(resume);
+    }
+
+    public Resume getResumeByUserId(String userId) {
+        return resumeRepository.findByUserId(userId)
+                .orElseThrow(() -> new ResumeNotFoundException("Resume not found"));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,11 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.open-in-view=false
 
+# Resume upload configuration
+resume.upload.dir=uploads/resumes
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB
+
 # ------- DOCKER CONFIGURATION - DO NOT MODIFY -------
 
 ## PostgreSQL Database Config


### PR DESCRIPTION
Solved Issue : #52 

- Added Resume entity, DTOs, repository, service, and controller.
- Implemented POST /api/resumes for uploading PDF/DOCX files (max 5MB) linked to users.
- Implemented GET /api/resumes/{userId} to fetch/download user resumes.
- Added basic validation for file type and size.
- Tested both endpoints successfully (screenshots attached for POST and GET requests).

<img width="1373" height="861" alt="Screenshot 2025-12-27 221245" src="https://github.com/user-attachments/assets/7d07db11-33c7-4202-ad8a-baa8e3b235d4" />
<img width="1369" height="877" alt="Screenshot 2025-12-27 221341" src="https://github.com/user-attachments/assets/a5b82f0b-4d82-4996-aac0-f791a6324dd3" />