### PR TITLE
Implemented Group-Chat endpoint

### DIFF
--- a/src/main/java/com/opencode/alumxbackend/groupchat/controller/GroupChatController.java
+++ b/src/main/java/com/opencode/alumxbackend/groupchat/controller/GroupChatController.java
@@ -1,0 +1,24 @@
+package com.opencode.alumxbackend.groupchat.controller;
+
+import com.opencode.alumxbackend.groupchat.dto.GroupChatRequest;
+import com.opencode.alumxbackend.groupchat.model.GroupChat;
+import com.opencode.alumxbackend.groupchat.service.GroupChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+
+@RestController
+@RequestMapping("/api/group-chats")
+@RequiredArgsConstructor
+public class GroupChatController {
+
+    private final GroupChatService service;
+
+    @PostMapping
+    public ResponseEntity<GroupChat> createGroup(@Valid @RequestBody GroupChatRequest request){
+        GroupChat group = service.createGroup(request);
+        return ResponseEntity.ok(group);
+    }
+}

--- a/src/main/java/com/opencode/alumxbackend/groupchat/dto/GroupChatRequest.java
+++ b/src/main/java/com/opencode/alumxbackend/groupchat/dto/GroupChatRequest.java
@@ -1,0 +1,26 @@
+package com.opencode.alumxbackend.groupchat.dto;
+
+import lombok.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupChatRequest {
+    @NotBlank(message = "Group name is required")
+    private String name;
+
+    @Size(min = 2, message = "At least 2 participants required")
+    private List<ParticipantRequest> participants;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ParticipantRequest {
+        private String userId;
+        private String username;
+    }
+}

--- a/src/main/java/com/opencode/alumxbackend/groupchat/dto/GroupChatResponse.java
+++ b/src/main/java/com/opencode/alumxbackend/groupchat/dto/GroupChatResponse.java
@@ -1,0 +1,16 @@
+package com.opencode.alumxbackend.groupchat.dto;
+
+import com.opencode.alumxbackend.groupchat.model.GroupChat.Participant;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupChatResponse {
+    private String groupId;
+    private String name;
+    private List<Participant> participants;
+}

--- a/src/main/java/com/opencode/alumxbackend/groupchat/model/GroupChat.java
+++ b/src/main/java/com/opencode/alumxbackend/groupchat/model/GroupChat.java
@@ -1,0 +1,37 @@
+package com.opencode.alumxbackend.groupchat.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "group_chats")
+public class GroupChat {
+    @Id
+    private String groupId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ElementCollection
+    private List<Participant> participants;
+
+    private LocalDateTime createdAt;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Embeddable
+    public static class Participant {
+        private String userId;
+        private String username;
+    }
+}

--- a/src/main/java/com/opencode/alumxbackend/groupchat/repository/GroupChatRepository.java
+++ b/src/main/java/com/opencode/alumxbackend/groupchat/repository/GroupChatRepository.java
@@ -1,0 +1,6 @@
+package com.opencode.alumxbackend.groupchat.repository;
+
+import com.opencode.alumxbackend.groupchat.model.GroupChat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupChatRepository extends JpaRepository<GroupChat, String> {}

--- a/src/main/java/com/opencode/alumxbackend/groupchat/service/GroupChatService.java
+++ b/src/main/java/com/opencode/alumxbackend/groupchat/service/GroupChatService.java
@@ -1,0 +1,38 @@
+package com.opencode.alumxbackend.groupchat.service;
+
+import com.opencode.alumxbackend.groupchat.dto.GroupChatRequest;
+import com.opencode.alumxbackend.groupchat.model.GroupChat;
+import com.opencode.alumxbackend.groupchat.model.GroupChat.Participant;
+import com.opencode.alumxbackend.groupchat.repository.GroupChatRepository;
+import lombok.*;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GroupChatService {
+    private final GroupChatRepository repository;
+
+    public GroupChat createGroup(GroupChatRequest request){
+        // Remove duplicate participants
+        List<Participant> participants = request.getParticipants().stream()
+                .distinct()
+                .map(p -> new GroupChat.Participant(p.getUserId(), p.getUsername()))
+                .collect(Collectors.toList());
+
+        String groupId = UUID.randomUUID().toString();
+
+        GroupChat group = GroupChat.builder()
+                .groupId(groupId)
+                .name(request.getName())
+                .participants(participants)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        return repository.save(group);
+    }
+}


### PR DESCRIPTION
Solved Issue: #61

Implemented Group Chat feature with a new API endpoint that allows users to create group chats with a name, description, and multiple participants.

Validation :
Create group with atleast 2 participants.

Screenshots:

<img width="1363" height="874" alt="Screenshot 2025-12-27 234532" src="https://github.com/user-attachments/assets/4365c156-5dac-4c8d-860f-0bc7ee6db422" />
<img width="1352" height="774" alt="Screenshot 2025-12-27 234610" src="https://github.com/user-attachments/assets/b7ca565d-4469-4d0c-9807-e073a9806b3b" />
