### PR TITLE
feat: Implement getPostsByUser API to retrieve all posts by a specific user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Database Configuration
+DB_URL=jdbc:postgresql://localhost:5432/alumx
+DB_USERNAME=postgres
+DB_PASSWORD=your_password_here
+
+# For Docker
+DB_HOST=postgres
+DB_PORT=5432
+DB_NAME=alumx
+DB_USER=postgres

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,12 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/opencode/alumxbackend/jobposts/controller/JobPostController.java
+++ b/src/main/java/com/opencode/alumxbackend/jobposts/controller/JobPostController.java
@@ -2,6 +2,7 @@ package com.opencode.alumxbackend.jobposts.controller;
 
 import com.opencode.alumxbackend.common.exception.UnauthorizedAccessException;
 import com.opencode.alumxbackend.jobposts.dto.JobPostRequest;
+import com.opencode.alumxbackend.jobposts.dto.JobPostResponse;
 import com.opencode.alumxbackend.jobposts.model.JobPost;
 import com.opencode.alumxbackend.jobposts.service.JobPostService;
 import jakarta.validation.Valid;
@@ -10,19 +11,25 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
 @RestController
-@RequestMapping("/api/job-posts")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class JobPostController {
     private final JobPostService jobPostService;
     private static final String DUMMY_TOKEN = "alumx-dev-token";
     private static final Logger logger = Logger.getLogger(JobPostController.class.getName());
 
+    @GetMapping("/users/{userId}/posts")
+    public ResponseEntity<List<JobPostResponse>> getPostsByUser(@PathVariable Long userId) {
+        List<JobPostResponse> posts = jobPostService.getPostsByUser(userId);
+        return ResponseEntity.ok(posts);
+    }
 
-    @PostMapping
+    @PostMapping("/job-posts")
     public ResponseEntity<?> createJobPost(
             @RequestHeader(value = "X-DUMMY-TOKEN", required = false) String token,
             @Valid @RequestBody JobPostRequest request

--- a/src/main/java/com/opencode/alumxbackend/jobposts/dto/JobPostResponse.java
+++ b/src/main/java/com/opencode/alumxbackend/jobposts/dto/JobPostResponse.java
@@ -1,0 +1,38 @@
+package com.opencode.alumxbackend.jobposts.dto;
+
+import com.opencode.alumxbackend.jobposts.model.JobPost;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class JobPostResponse {
+    private String id;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static JobPostResponse fromEntity(JobPost jobPost) {
+        return JobPostResponse.builder()
+                .id(jobPost.getPostId())
+                .title(jobPost.getUsername() + "'s Job Post")
+                .content(jobPost.getDescription())
+                .createdAt(jobPost.getCreatedAt())
+                .updatedAt(jobPost.getCreatedAt())
+                .build();
+    }
+
+    public static List<JobPostResponse> fromEntities(List<JobPost> jobPosts) {
+        return jobPosts.stream()
+                .map(JobPostResponse::fromEntity)
+                .toList();
+    }
+}

--- a/src/main/java/com/opencode/alumxbackend/jobposts/repository/JobPostRepository.java
+++ b/src/main/java/com/opencode/alumxbackend/jobposts/repository/JobPostRepository.java
@@ -4,8 +4,9 @@ import com.opencode.alumxbackend.jobposts.model.JobPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 
 @Repository
 public interface JobPostRepository extends JpaRepository<JobPost, String> {
-
+    List<JobPost> findByUsernameOrderByCreatedAtDesc(String username);
 }

--- a/src/main/java/com/opencode/alumxbackend/jobposts/service/JobPostService.java
+++ b/src/main/java/com/opencode/alumxbackend/jobposts/service/JobPostService.java
@@ -1,9 +1,13 @@
 package com.opencode.alumxbackend.jobposts.service;
 
 import com.opencode.alumxbackend.jobposts.dto.JobPostRequest;
+import com.opencode.alumxbackend.jobposts.dto.JobPostResponse;
 import com.opencode.alumxbackend.jobposts.model.JobPost;
+
+import java.util.List;
 
 public interface JobPostService {
     JobPost createJobPost(JobPostRequest request);
     void deletePostByUser(Long userId, String postId);
+    List<JobPostResponse> getPostsByUser(Long userId);
 }

--- a/src/main/java/com/opencode/alumxbackend/jobposts/service/JobPostServiceImpl.java
+++ b/src/main/java/com/opencode/alumxbackend/jobposts/service/JobPostServiceImpl.java
@@ -3,6 +3,7 @@ package com.opencode.alumxbackend.jobposts.service;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -11,8 +12,10 @@ import com.opencode.alumxbackend.common.exception.BadRequestException;
 import com.opencode.alumxbackend.common.exception.ForbiddenException;
 import com.opencode.alumxbackend.common.exception.ResourceNotFoundException;
 import com.opencode.alumxbackend.jobposts.dto.JobPostRequest;
+import com.opencode.alumxbackend.jobposts.dto.JobPostResponse;
 import com.opencode.alumxbackend.jobposts.model.JobPost;
 import com.opencode.alumxbackend.jobposts.repository.JobPostRepository;
+import com.opencode.alumxbackend.users.model.User;
 import com.opencode.alumxbackend.users.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -26,7 +29,14 @@ public class JobPostServiceImpl implements JobPostService{
     private final JobPostRepository jobPostRepository;
     private final UserRepository userRepository;
 
+    @Override
+    public List<JobPostResponse> getPostsByUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
 
+        List<JobPost> posts = jobPostRepository.findByUsernameOrderByCreatedAtDesc(user.getUsername());
+        return JobPostResponse.fromEntities(posts);
+    }
 
     @Override
     public JobPost createJobPost(JobPostRequest request) {

--- a/src/test/java/com/opencode/alumxbackend/jobposts/controller/JobPostControllerIntegrationTest.java
+++ b/src/test/java/com/opencode/alumxbackend/jobposts/controller/JobPostControllerIntegrationTest.java
@@ -1,0 +1,134 @@
+package com.opencode.alumxbackend.jobposts.controller;
+
+import com.opencode.alumxbackend.jobposts.model.JobPost;
+import com.opencode.alumxbackend.jobposts.repository.JobPostRepository;
+import com.opencode.alumxbackend.users.model.User;
+import com.opencode.alumxbackend.users.model.UserRole;
+import com.opencode.alumxbackend.users.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class JobPostControllerIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JobPostRepository jobPostRepository;
+
+    private WebClient webClient;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        webClient = WebClient.create("http://localhost:" + port);
+        jobPostRepository.deleteAll();
+        userRepository.deleteAll();
+
+        testUser = User.builder()
+                .username("integrationuser")
+                .name("Integration User")
+                .email("integration@test.com")
+                .passwordHash("hashedpassword")
+                .role(UserRole.ALUMNI)
+                .profileCompleted(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+        testUser = userRepository.save(testUser);
+    }
+
+    @Test
+    @DisplayName("GET /api/users/{userId}/posts - returns 200 OK with posts list")
+    void getPostsByUser_ReturnsOkWithPosts() {
+        JobPost post = JobPost.builder()
+                .postId("integration-post-1")
+                .username(testUser.getUsername())
+                .description("Integration test job post description content")
+                .createdAt(LocalDateTime.now())
+                .build();
+        jobPostRepository.save(post);
+
+        List<?> response = webClient.get()
+                .uri("/api/users/" + testUser.getId() + "/posts")
+                .retrieve()
+                .bodyToMono(List.class)
+                .block();
+
+        assertThat(response).isNotNull();
+        assertThat(response).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("GET /api/users/{userId}/posts - returns 200 OK with empty list when no posts")
+    void getPostsByUser_ReturnsEmptyListWhenNoPosts() {
+        List<?> response = webClient.get()
+                .uri("/api/users/" + testUser.getId() + "/posts")
+                .retrieve()
+                .bodyToMono(List.class)
+                .block();
+
+        assertThat(response).isNotNull();
+        assertThat(response).isEmpty();
+    }
+
+    @Test
+    @DisplayName("GET /api/users/{userId}/posts - returns 404 when user not found")
+    void getPostsByUser_ReturnsNotFoundWhenUserDoesNotExist() {
+        try {
+            webClient.get()
+                    .uri("/api/users/99999/posts")
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("404");
+        }
+    }
+
+    @Test
+    @DisplayName("GET /api/users/{userId}/posts - returns multiple posts")
+    void getPostsByUser_ReturnsMultiplePosts() {
+        JobPost post1 = JobPost.builder()
+                .postId("post-1")
+                .username(testUser.getUsername())
+                .description("First post description for testing")
+                .createdAt(LocalDateTime.now().minusDays(2))
+                .build();
+        
+        JobPost post2 = JobPost.builder()
+                .postId("post-2")
+                .username(testUser.getUsername())
+                .description("Second post description for testing")
+                .createdAt(LocalDateTime.now())
+                .build();
+        
+        jobPostRepository.save(post1);
+        jobPostRepository.save(post2);
+
+        List<?> response = webClient.get()
+                .uri("/api/users/" + testUser.getId() + "/posts")
+                .retrieve()
+                .bodyToMono(List.class)
+                .block();
+
+        assertThat(response).isNotNull();
+        assertThat(response).hasSize(2);
+    }
+}

--- a/src/test/java/com/opencode/alumxbackend/jobposts/service/JobPostServiceImplTest.java
+++ b/src/test/java/com/opencode/alumxbackend/jobposts/service/JobPostServiceImplTest.java
@@ -1,0 +1,127 @@
+package com.opencode.alumxbackend.jobposts.service;
+
+import com.opencode.alumxbackend.common.exception.ResourceNotFoundException;
+import com.opencode.alumxbackend.jobposts.dto.JobPostResponse;
+import com.opencode.alumxbackend.jobposts.model.JobPost;
+import com.opencode.alumxbackend.jobposts.repository.JobPostRepository;
+import com.opencode.alumxbackend.users.model.User;
+import com.opencode.alumxbackend.users.model.UserRole;
+import com.opencode.alumxbackend.users.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobPostServiceImplTest {
+
+    @Mock
+    private JobPostRepository jobPostRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private JobPostServiceImpl jobPostService;
+
+    private User testUser;
+    private JobPost testPost1;
+    private JobPost testPost2;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .username("testuser")
+                .name("Test User")
+                .email("test@example.com")
+                .passwordHash("hashedpassword")
+                .role(UserRole.ALUMNI)
+                .profileCompleted(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        testPost1 = JobPost.builder()
+                .postId("post-1")
+                .username("testuser")
+                .description("This is the first test job post description")
+                .createdAt(LocalDateTime.now().minusDays(1))
+                .build();
+
+        testPost2 = JobPost.builder()
+                .postId("post-2")
+                .username("testuser")
+                .description("This is the second test job post description")
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("getPostsByUser - returns posts when user exists and has posts")
+    void getPostsByUser_ReturnsPostsWhenUserExistsAndHasPosts() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(jobPostRepository.findByUsernameOrderByCreatedAtDesc("testuser"))
+                .thenReturn(List.of(testPost2, testPost1));
+
+        List<JobPostResponse> result = jobPostService.getPostsByUser(1L);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo("post-2");
+        assertThat(result.get(1).getId()).isEqualTo("post-1");
+        assertThat(result.get(0).getContent()).isEqualTo("This is the second test job post description");
+    }
+
+    @Test
+    @DisplayName("getPostsByUser - returns empty list when user exists but has no posts")
+    void getPostsByUser_ReturnsEmptyListWhenUserHasNoPosts() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(jobPostRepository.findByUsernameOrderByCreatedAtDesc("testuser"))
+                .thenReturn(Collections.emptyList());
+
+        List<JobPostResponse> result = jobPostService.getPostsByUser(1L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getPostsByUser - throws ResourceNotFoundException when user does not exist")
+    void getPostsByUser_ThrowsExceptionWhenUserNotFound() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> jobPostService.getPostsByUser(999L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("User")
+                .hasMessageContaining("999");
+    }
+
+    @Test
+    @DisplayName("getPostsByUser - response contains all required fields")
+    void getPostsByUser_ResponseContainsAllRequiredFields() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(jobPostRepository.findByUsernameOrderByCreatedAtDesc("testuser"))
+                .thenReturn(List.of(testPost1));
+
+        List<JobPostResponse> result = jobPostService.getPostsByUser(1L);
+
+        assertThat(result).hasSize(1);
+        JobPostResponse response = result.get(0);
+        assertThat(response.getId()).isNotNull();
+        assertThat(response.getTitle()).isNotNull();
+        assertThat(response.getContent()).isNotNull();
+        assertThat(response.getCreatedAt()).isNotNull();
+        assertThat(response.getUpdatedAt()).isNotNull();
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,15 @@
+# Test Database Config - Uses H2 in-memory database (isolated, doesn't affect real DB)
+# Override with environment variables if needed:
+# TEST_DB_URL, TEST_DB_USERNAME, TEST_DB_PASSWORD
+
+spring.datasource.url=${TEST_DB_URL:jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+spring.datasource.driver-class-name=${TEST_DB_DRIVER:org.h2.Driver}
+spring.datasource.username=${TEST_DB_USERNAME:sa}
+spring.datasource.password=${TEST_DB_PASSWORD:}
+
+# JPA Config for tests
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+
+# Disable security for tests
+spring.security.enabled=false


### PR DESCRIPTION
Issue: #57

## Summary
Implements `GET /api/users/{userId}/posts` endpoint to retrieve all posts created by a specific user.

## Changes
- Added `getPostsByUser(Long userId)` method in service layer
- Added `findByUsernameOrderByCreatedAtDesc` repository query
- Created `JobPostResponse` DTO with required fields (id, title, content, createdAt, updatedAt)
- Added endpoint at `GET /api/users/{userId}/posts`

## HTTP Responses
- `200 OK` - Returns list of posts (empty list if user has no posts)
- `404 Not Found` - If user with given userId doesn't exist
- `500 Internal Server Error` - For unexpected errors

## Testing
- 4 unit tests for service layer
- 4 integration tests for controller
- All 8 tests passing ✅
