### PR TITLE
Fix: Security vulnerability - Unrestricted API access and CSRF disabled

### DIFF
--- a/src/main/java/com/opencode/alumxbackend/common/SecurityConfig.java
+++ b/src/main/java/com/opencode/alumxbackend/common/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -21,8 +22,21 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf->csrf.disable())
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+                // Disable CSRF only because we're using stateless JWT-style auth (no sessions)
+                .csrf(AbstractHttpConfigurer::disable)
+                // Stateless session - no session cookies, each request must be authenticated
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        // Public endpoints - health check and basic info
+                        .requestMatchers("/", "/health", "/actuator/health").permitAll()
+                        // Public endpoints - user registration
+                        .requestMatchers("/api/users").permitAll()
+                        // Public endpoints - mentor basics
+                        .requestMatchers("/basics/**").permitAll()
+                        // All other API endpoints require authentication
+                        .anyRequest().authenticated()
+                );
         return http.build();
     }
 }


### PR DESCRIPTION
## Problem

The current security setup had critical vulnerabilities:
- `csrf.disable()` without justification
- `anyRequest().permitAll()` leaving all endpoints publicly accessible

## Impact
- All endpoints were publicly accessible without authentication
- User data could be read or modified by anyone
- Admin-level actions could be performed without authorization
- High risk for data abuse and spam

## Solution
- Added stateless session management (`SessionCreationPolicy.STATELESS`) to justify CSRF being disabled (valid for JWT/token-based auth)
- Defined explicit public endpoints: `/`, `/health`, `/api/users` (registration), `/basics/**`
- All other API endpoints now require authentication

## Testing
- Verified no compilation errors in SecurityConfig.java
- Protected routes will return 401/403 without valid authentication
