### PR TITLE
Add database diagram link to README for issue #125

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,34 @@ Spring Boot API Gateway
 
 ---
 
+## Database Schema (High Level)
+
+### Complete Database Diagram
+
+View the complete, interactive database schema diagram here:
+
+**[AlumX Database Diagram - Interactive View](https://dbdiagram.io/d/database-diagram-695381be39fa3db27bcae256)**
+
+The diagram includes:
+- **9 main entities**: User, Chat, Message, GroupChat, Participant, GroupMessage, JobPost, JobPostComment, JobPostLike, Resume
+- **12 user profile collection tables**: skills, education, tech_stack, languages, frameworks, communication_skills, certifications, projects, soft_skills, hobbies, experience, internships
+- **All relationships** properly mapped with foreign keys and cardinality (1:1, 1:N, N:M)
+- **Indexes and constraints** as defined in the codebase
+
+### Database Tables Overview
+
+The AlumX backend uses the following main entity groups:
+
+1. **User Management** - Core user profiles with role-based access (Student, Alumni, Professor)
+2. **Chat System** - One-on-one messaging between users
+3. **Group Chat** - Multi-user group conversations with participants
+4. **Job Posts** - Alumni experience sharing with engagement features (likes, comments)
+5. **Resume System** - AI-assisted resume management for users
+
+All tables follow proper normalization principles and include appropriate indexes for optimal query performance.
+
+---
+
 ## 🛠️ Project Setup
 This project uses **Spring Boot + PostgreSQL** and reads configuration from **environment variables** to keep secrets out of the codebase.
 


### PR DESCRIPTION
Issue : #125

## Summary
Created a comprehensive database diagram for the AlumX project using DBDiagram.io and integrated it into the README documentation.

## Changes Made
- Added interactive database diagram link to README.md under "Database Schema (High Level)" section
- Documented all 21 database tables (9 main entities + 12 user profile collections)
- Mapped all relationships with proper cardinality (1:1, 1:N, N:M)
- Included primary keys, foreign keys, indexes, and constraints

## Diagram Details
The diagram visualizes:
- User management system with complete profile collections
- Chat systems (1-on-1 and group messaging)
- Job posts (alumni blog system) with comments and likes
- Resume management system
- All relationships between entities

All entities are based on the actual codebase and accurately reflect the current database structure.

## Interactive Diagram Link
https://dbdiagram.io/d/database-diagram-695381be39fa3db27bcae256

The diagram is clean and readable, showing all table connections with proper relationship notation.