### PR TITLE
Add user search API with profile-based matching

### DIFF
--- a/src/main/java/com/opencode/alumxbackend/search/controller/UserSearchController.java
+++ b/src/main/java/com/opencode/alumxbackend/search/controller/UserSearchController.java
@@ -1,0 +1,23 @@
+package com.opencode.alumxbackend.search.controller;
+
+import com.opencode.alumxbackend.users.dto.UserResponseDto;
+import com.opencode.alumxbackend.users.model.User;
+import com.opencode.alumxbackend.search.service.UserSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserSearchController {
+
+    private final UserSearchService service;
+
+    @GetMapping("/search")
+    public ResponseEntity<List<UserResponseDto>> searchUsers(@RequestParam("q") String query) {
+        return ResponseEntity.ok(service.search(query));
+    }
+}

--- a/src/main/java/com/opencode/alumxbackend/search/repository/UserSearchRepository.java
+++ b/src/main/java/com/opencode/alumxbackend/search/repository/UserSearchRepository.java
@@ -1,0 +1,9 @@
+package com.opencode.alumxbackend.search.repository;
+
+import com.opencode.alumxbackend.users.dto.UserResponseDto;
+import com.opencode.alumxbackend.users.model.User;
+import java.util.List;
+
+public interface UserSearchRepository {
+    List<UserResponseDto> searchUsers(String query);
+}

--- a/src/main/java/com/opencode/alumxbackend/search/repository/UserSearchRepositoryImpl.java
+++ b/src/main/java/com/opencode/alumxbackend/search/repository/UserSearchRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.opencode.alumxbackend.search.repository;
+
+import com.opencode.alumxbackend.users.dto.UserResponseDto;
+import com.opencode.alumxbackend.users.model.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class UserSearchRepositoryImpl implements UserSearchRepository {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public List<UserResponseDto> searchUsers(String query) {
+
+        String jpql = """
+    SELECT DISTINCT new com.opencode.alumxbackend.users.dto.UserResponseDto(
+        u.id,
+        u.name,
+        u.email,
+        u.role,
+        u.createdAt
+    )
+    FROM User u
+    LEFT JOIN u.education e
+    LEFT JOIN u.experience exp
+    LEFT JOIN u.internships i
+    WHERE LOWER(u.username) LIKE LOWER(CONCAT('%', :q, '%'))
+       OR LOWER(u.name) LIKE LOWER(CONCAT('%', :q, '%'))
+       OR LOWER(u.currentCompany) LIKE LOWER(CONCAT('%', :q, '%'))
+       OR LOWER(e) LIKE LOWER(CONCAT('%', :q, '%'))
+       OR LOWER(exp) LIKE LOWER(CONCAT('%', :q, '%'))
+       OR LOWER(i) LIKE LOWER(CONCAT('%', :q, '%'))
+""";
+
+
+        return entityManager.createQuery(jpql, UserResponseDto.class)
+                .setParameter("q", query)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/opencode/alumxbackend/search/service/UserSearchService.java
+++ b/src/main/java/com/opencode/alumxbackend/search/service/UserSearchService.java
@@ -1,0 +1,9 @@
+package com.opencode.alumxbackend.search.service;
+
+import com.opencode.alumxbackend.users.dto.UserResponseDto;
+import com.opencode.alumxbackend.users.model.User;
+import java.util.List;
+
+public interface UserSearchService {
+    List<UserResponseDto> search(String query);
+}

--- a/src/main/java/com/opencode/alumxbackend/search/service/UserSearchServiceImpl.java
+++ b/src/main/java/com/opencode/alumxbackend/search/service/UserSearchServiceImpl.java
@@ -1,0 +1,24 @@
+package com.opencode.alumxbackend.search.service;
+
+import com.opencode.alumxbackend.users.dto.UserResponseDto;
+import com.opencode.alumxbackend.users.model.User;
+import com.opencode.alumxbackend.search.repository.UserSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserSearchServiceImpl implements UserSearchService {
+
+    private final UserSearchRepository repository;
+
+    @Override
+    public List<UserResponseDto> search(String query) {
+        if (query == null || query.trim().isEmpty()) {
+            throw new IllegalArgumentException("Search query cannot be empty");
+        }
+        return repository.searchUsers(query.trim());
+    }
+}

--- a/src/test/java/com/opencode/alumxbackend/search/service/UserSearchServiceTest.java
+++ b/src/test/java/com/opencode/alumxbackend/search/service/UserSearchServiceTest.java
@@ -1,0 +1,46 @@
+package com.opencode.alumxbackend.search.service;
+
+import com.opencode.alumxbackend.users.dto.UserResponseDto;
+import com.opencode.alumxbackend.users.model.User;
+import com.opencode.alumxbackend.users.model.UserRole;
+import com.opencode.alumxbackend.users.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class UserSearchServiceTest {
+
+    @Autowired
+    private UserSearchService service;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void searchByUsername() {
+        User user = User.builder()
+                .username("hasan")
+                .name("Hasan Ravda")
+                .email("hasan@test.com")
+                .passwordHash("pass")
+                .role(UserRole.STUDENT)
+                .profileCompleted(true)
+                .build();
+
+        userRepository.save(user);
+
+        List<UserResponseDto> result = service.search("has");
+
+        assertFalse(result.isEmpty());
+    }
+}


### PR DESCRIPTION
Solves Issue:#159


Implemented a query-based user search feature to improve user discovery on the platform. Added a new search module that allows searching users using a single keyword across username and profile-related fields like education, experience, internships, and current company.
/api/users/search?q=

Implemented a query-based user search feature to improve user discovery on the platform. Added a new search module that allows searching users using a single keyword across username and profile-related fields like education, experience, internships, and current company.

Also added a Unit test case for this service

Screenshot - 
<img width="1376" height="863" alt="Screenshot 2025-12-31 170914" src="https://github.com/user-attachments/assets/9c55355a-59c0-4441-af6e-bdb902b50bfb" />
