### PR TITLE
feat: add message read/unread status tracking (#211)

### DIFF
--- a/src/main/java/com/opencode/alumxbackend/chatreadreceipt/controller/ChatReadController.java
+++ b/src/main/java/com/opencode/alumxbackend/chatreadreceipt/controller/ChatReadController.java
@@ -1,0 +1,51 @@
+package com.opencode.alumxbackend.chatreadreceipt.controller;
+
+import com.opencode.alumxbackend.chatreadreceipt.dto.ChatReadRequest;
+import com.opencode.alumxbackend.chatreadreceipt.dto.ChatReadResponse;
+import com.opencode.alumxbackend.chatreadreceipt.dto.UnreadCountResponse;
+import com.opencode.alumxbackend.chatreadreceipt.service.ChatReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/chats")
+@RequiredArgsConstructor
+public class ChatReadController {
+
+    private final ChatReadService chatReadService;
+
+    @PostMapping("/{chatId}/read")
+    public ResponseEntity<ChatReadResponse> updateRead(
+            @PathVariable Long chatId,
+            @RequestBody ChatReadRequest request) {
+        ChatReadResponse response = chatReadService.updateLastRead(
+                chatId, request.getUserId(), request.getLastReadMessageId());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{chatId}/last-read/{userId}")
+    public ResponseEntity<ChatReadResponse> getLastRead(
+            @PathVariable Long chatId,
+            @PathVariable Long userId) {
+        ChatReadResponse response = chatReadService.getLastReadMessage(chatId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{chatId}/unread-count/{userId}")
+    public ResponseEntity<UnreadCountResponse> getUnreadCount(
+            @PathVariable Long chatId,
+            @PathVariable Long userId) {
+        UnreadCountResponse response = chatReadService.getUnreadCount(chatId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/unread-counts/{userId}")
+    public ResponseEntity<List<UnreadCountResponse>> getAllUnreadCounts(
+            @PathVariable Long userId) {
+        List<UnreadCountResponse> response = chatReadService.getAllUnreadCounts(userId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/opencode/alumxbackend/chatreadreceipt/dto/ChatReadRequest.java
+++ b/src/main/java/com/opencode/alumxbackend/chatreadreceipt/dto/ChatReadRequest.java
@@ -1,0 +1,13 @@
+package com.opencode.alumxbackend.chatreadreceipt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatReadRequest {
+    private Long userId;
+    private Long lastReadMessageId;
+}

--- a/src/main/java/com/opencode/alumxbackend/chatreadreceipt/dto/ChatReadResponse.java
+++ b/src/main/java/com/opencode/alumxbackend/chatreadreceipt/dto/ChatReadResponse.java
@@ -1,0 +1,13 @@
+package com.opencode.alumxbackend.chatreadreceipt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatReadResponse {
+    private Long userId;
+    private Long lastReadMessageId;
+}

--- a/src/main/java/com/opencode/alumxbackend/chatreadreceipt/dto/UnreadCountResponse.java
+++ b/src/main/java/com/opencode/alumxbackend/chatreadreceipt/dto/UnreadCountResponse.java
@@ -1,0 +1,14 @@
+package com.opencode.alumxbackend.chatreadreceipt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UnreadCountResponse {
+    private Long chatId;
+    private Long userId;
+    private Long unreadCount;
+}

--- a/src/main/java/com/opencode/alumxbackend/chatreadreceipt/model/ChatReadState.java
+++ b/src/main/java/com/opencode/alumxbackend/chatreadreceipt/model/ChatReadState.java
@@ -1,0 +1,36 @@
+package com.opencode.alumxbackend.chatreadreceipt.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "chat_read_states",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_chat_user", columnNames = {"chat_id", "user_id"})
+        },
+        indexes = {
+                @Index(name = "idx_chat_read_chat_id", columnList = "chat_id"),
+                @Index(name = "idx_chat_read_user_id", columnList = "user_id")
+        })
+@Builder
+public class ChatReadState {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "chat_id", nullable = false)
+    private Long chatId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "last_read_message_id")
+    private Long lastReadMessageId;
+}

--- a/src/main/java/com/opencode/alumxbackend/chatreadreceipt/repository/ChatReadStateRepository.java
+++ b/src/main/java/com/opencode/alumxbackend/chatreadreceipt/repository/ChatReadStateRepository.java
@@ -1,0 +1,32 @@
+package com.opencode.alumxbackend.chatreadreceipt.repository;
+
+import com.opencode.alumxbackend.chatreadreceipt.model.ChatReadState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatReadStateRepository extends JpaRepository<ChatReadState, Long> {
+
+    Optional<ChatReadState> findByChatIdAndUserId(Long chatId, Long userId);
+
+    List<ChatReadState> findByChatId(Long chatId);
+
+    List<ChatReadState> findByUserId(Long userId);
+
+    @Query("SELECT COUNT(m) FROM Message m WHERE m.chat.chatID = :chatId " +
+            "AND m.senderId != :userId " +
+            "AND m.messageID > :lastReadMessageId")
+    Long countUnreadMessages(@Param("chatId") Long chatId,
+                             @Param("userId") Long userId,
+                             @Param("lastReadMessageId") Long lastReadMessageId);
+
+    @Query("SELECT COUNT(m) FROM Message m WHERE m.chat.chatID = :chatId " +
+            "AND m.senderId != :userId")
+    Long countAllMessagesFromOther(@Param("chatId") Long chatId,
+                                   @Param("userId") Long userId);
+}

--- a/src/main/java/com/opencode/alumxbackend/chatreadreceipt/service/ChatReadService.java
+++ b/src/main/java/com/opencode/alumxbackend/chatreadreceipt/service/ChatReadService.java
@@ -1,0 +1,17 @@
+package com.opencode.alumxbackend.chatreadreceipt.service;
+
+import com.opencode.alumxbackend.chatreadreceipt.dto.ChatReadResponse;
+import com.opencode.alumxbackend.chatreadreceipt.dto.UnreadCountResponse;
+
+import java.util.List;
+
+public interface ChatReadService {
+
+    ChatReadResponse updateLastRead(Long chatId, Long userId, Long lastReadMessageId);
+
+    ChatReadResponse getLastReadMessage(Long chatId, Long userId);
+
+    UnreadCountResponse getUnreadCount(Long chatId, Long userId);
+
+    List<UnreadCountResponse> getAllUnreadCounts(Long userId);
+}

--- a/src/main/java/com/opencode/alumxbackend/chatreadreceipt/service/ChatReadServiceImpl.java
+++ b/src/main/java/com/opencode/alumxbackend/chatreadreceipt/service/ChatReadServiceImpl.java
@@ -1,0 +1,94 @@
+package com.opencode.alumxbackend.chatreadreceipt.service;
+
+import com.opencode.alumxbackend.chat.model.Chat;
+import com.opencode.alumxbackend.chat.repository.ChatRepository;
+import com.opencode.alumxbackend.chatreadreceipt.dto.ChatReadResponse;
+import com.opencode.alumxbackend.chatreadreceipt.dto.UnreadCountResponse;
+import com.opencode.alumxbackend.chatreadreceipt.model.ChatReadState;
+import com.opencode.alumxbackend.chatreadreceipt.repository.ChatReadStateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatReadServiceImpl implements ChatReadService {
+
+    private final ChatReadStateRepository chatReadStateRepository;
+    private final ChatRepository chatRepository;
+
+    @Override
+    public ChatReadResponse updateLastRead(Long chatId, Long userId, Long lastReadMessageId) {
+        ChatReadState state = chatReadStateRepository.findByChatIdAndUserId(chatId, userId)
+                .orElse(ChatReadState.builder()
+                        .chatId(chatId)
+                        .userId(userId)
+                        .lastReadMessageId(lastReadMessageId)
+                        .build());
+
+        if (state.getLastReadMessageId() == null || lastReadMessageId > state.getLastReadMessageId()) {
+            state.setLastReadMessageId(lastReadMessageId);
+            chatReadStateRepository.save(state);
+        }
+
+        return new ChatReadResponse(state.getUserId(), state.getLastReadMessageId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ChatReadResponse getLastReadMessage(Long chatId, Long userId) {
+        return chatReadStateRepository.findByChatIdAndUserId(chatId, userId)
+                .map(state -> new ChatReadResponse(state.getUserId(), state.getLastReadMessageId()))
+                .orElse(new ChatReadResponse(userId, null));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UnreadCountResponse getUnreadCount(Long chatId, Long userId) {
+        Long lastReadMessageId = chatReadStateRepository.findByChatIdAndUserId(chatId, userId)
+                .map(ChatReadState::getLastReadMessageId)
+                .orElse(null);
+
+        Long unreadCount;
+        if (lastReadMessageId == null) {
+            unreadCount = chatReadStateRepository.countAllMessagesFromOther(chatId, userId);
+        } else {
+            unreadCount = chatReadStateRepository.countUnreadMessages(chatId, userId, lastReadMessageId);
+        }
+
+        return new UnreadCountResponse(chatId, userId, unreadCount);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<UnreadCountResponse> getAllUnreadCounts(Long userId) {
+        List<Chat> userChats = chatRepository.findAll().stream()
+                .filter(chat -> chat.getUser1Id().equals(userId) || chat.getUser2Id().equals(userId))
+                .collect(Collectors.toList());
+
+        Map<Long, Long> readStates = chatReadStateRepository.findByUserId(userId).stream()
+                .collect(Collectors.toMap(ChatReadState::getChatId, ChatReadState::getLastReadMessageId));
+
+        List<UnreadCountResponse> results = new ArrayList<>();
+        for (Chat chat : userChats) {
+            Long lastReadMessageId = readStates.get(chat.getChatID());
+            Long unreadCount;
+
+            if (lastReadMessageId == null) {
+                unreadCount = chatReadStateRepository.countAllMessagesFromOther(chat.getChatID(), userId);
+            } else {
+                unreadCount = chatReadStateRepository.countUnreadMessages(chat.getChatID(), userId, lastReadMessageId);
+            }
+
+            results.add(new UnreadCountResponse(chat.getChatID(), userId, unreadCount));
+        }
+
+        return results;
+    }
+}


### PR DESCRIPTION
- Add ChatReadState entity to track last read message per user per chat
- Add ChatReadStateRepository with unread count queries
- Add ChatReadService with methods to update read status and get unread counts
- Add ChatReadController with REST endpoints:
  - POST /api/chats/{chatId}/read - mark messages as read
  - GET /api/chats/{chatId}/last-read/{userId} - get last read message
  - GET /api/chats/{chatId}/unread-count/{userId} - get unread count per chat
  - GET /api/chats/unread-counts/{userId} - get all unread counts

Issue: #211 